### PR TITLE
Fix skip publish flag

### DIFF
--- a/cmd/gpm/commands/run.go
+++ b/cmd/gpm/commands/run.go
@@ -36,7 +36,7 @@ func init() {
 	generateCmd.Flags().String("tempPath", "/tmp",
 		"Temporal file for the generation of intermediate data")
 	generateCmd.Flags().StringVar(&appConfig.GeneratorName, "protoGenerator", "docker", "Implementation used to generate the proto code.")
-	generateCmd.Flags().Bool("skipPublish", false, "Flag to skip publishing the generated protos")
+	generateCmd.Flags().BoolVar(&appConfig.SkipPublish, "skipPublish", false, "Flag to skip publishing the generated protos")
 	err := viper.BindPFlag("tempPath", generateCmd.Flags().Lookup("tempPath"))
 	if err != nil {
 		log.Error().Err(err).Msg("unable to bind viper key")

--- a/internal/app/gpm/manager/manager.go
+++ b/internal/app/gpm/manager/manager.go
@@ -39,6 +39,7 @@ func (gpm *GPM) Run(basePath string) error {
 		log.Fatal().Err(err).Msg("invalid configuration options")
 	}
 	gpm.cfg.Print()
+	defer gpm.cleanup(basePath, gpm.cfg.TempPath)
 
 	repoProvider, err := repo.NewRepoProvider(gpm.cfg.RepositoryProvider)
 	if err != nil {
@@ -70,6 +71,26 @@ func (gpm *GPM) Run(basePath string) error {
 	}
 
 	return err
+}
+
+// cleanup function to delete temporal directories.
+func (gpm *GPM) cleanup(basePath string, tempPath string) {
+	log.Debug().Str("basePath", basePath).Str("tempPath", tempPath).Msg("cleaning temporal directories")
+	generatedPath := path.Join(basePath, "generated")
+	_, err := os.Stat(generatedPath)
+	if err == nil {
+		// Otherwise, assume directory has not being generated.
+		if rerr := os.RemoveAll(generatedPath); rerr != nil {
+			log.Warn().Str("generatedPath", generatedPath).Err(rerr).Msg("unable to deleted directory with temporal generated code")
+		}
+	}
+	_, err = os.Stat(tempPath)
+	if err == nil {
+		// Otherwise, assume directory has not being generated.
+		if rerr := os.RemoveAll(tempPath); rerr != nil {
+			log.Warn().Str("tempPath", tempPath).Err(rerr).Msg("unable to deleted directory with temporal downloaded code")
+		}
+	}
 }
 
 // isExcluded method to check if the directory should be excluded from the generation process.


### PR DESCRIPTION
This PR addresses the bugs found on https://github.com/dhiguero/grpc-proto-manager/issues/2

* `SkipPublish` flag not recognized properly.
* Temporal directories not cleaned up in the event of an error.